### PR TITLE
Copy action mask in reshape_action_mask before write in place.

### DIFF
--- a/stable_baselines/common/policies.py
+++ b/stable_baselines/common/policies.py
@@ -800,6 +800,8 @@ def create_dummy_action_mask(ac_space, num_samples):
 
 
 def reshape_action_mask(action_mask, ac_space, num_samples):
+    action_mask = np.copy(action_mask)
+
     if isinstance(ac_space, spaces.MultiDiscrete):
         action_mask = np.reshape(action_mask, [num_samples].extend(ac_space.nvec))
     elif isinstance(ac_space, spaces.Discrete) or isinstance(ac_space, spaces.MultiBinary):


### PR DESCRIPTION
Multiple places use reshape_action_mask, copy before writing in place.

Potentially a better way to do this would be to calc reshape once before passing it elsewhere.